### PR TITLE
Burst mode enhancement

### DIFF
--- a/DataConverter/ConverterExtensions.cs
+++ b/DataConverter/ConverterExtensions.cs
@@ -1,4 +1,3 @@
-﻿using System;
 using System.Collections.Immutable;
 using System.Linq;
 using WoWsShipBuilder.DataStructures.Ship;
@@ -8,9 +7,9 @@ namespace DataConverter;
 
 public static class ConverterExtensions
 {
-    public static Gun ConvertData(this WgGun wgGun, double taperDist, string wgGunIndex, decimal gunBaseAngle, ImmutableArray<string> additionalAmmo) => new()
+    public static Gun ConvertData(this WgGun wgGun, double taperDist, string wgGunIndex, decimal gunBaseAngle) => new()
     {
-        AmmoList = wgGun.AmmoList.Concat(additionalAmmo).ToImmutableArray(),
+        AmmoList = wgGun.AmmoList.ToImmutableArray(),
         BarrelDiameter = wgGun.BarrelDiameter,
         HorizontalSector = wgGun.HorizSector.ToImmutableArray(),
         HorizontalDeadZones = wgGun.DeadZone.Select(x => x.ToImmutableArray()).ToImmutableArray(),

--- a/DataConverter/Converters/ShipConverter.cs
+++ b/DataConverter/Converters/ShipConverter.cs
@@ -42,7 +42,7 @@ public static class ShipConverter
             DataCache.TranslationNames.Add(wgShip.Index);
             var stShip = shiptoolData.Ship.Find(s => s.Index.Equals(wgShip.Index));
             var upgradeInfo = ProcessUpgradeInfo(wgShip, logger);
-            var mainBatteries = ProcessMainBattery(wgShip, upgradeInfo, stShip, logger, modifiersDictionary);
+            var mainBatteries = ProcessMainBattery(wgShip, upgradeInfo, stShip, modifiersDictionary);
             var ship = new Ship
             {
                 Id = wgShip.Id,
@@ -110,14 +110,12 @@ public static class ShipConverter
     {
         if (module != null)
         {
-            var modifiers = new List<Modifier>
-            {
-                new("BurstModeEnabled", 1, shipName, new("", 0, string.Empty, string.Empty, Unit.None, ["MainBatteryDataContainer.BurstMode"], DisplayValueProcessingKind.Discard, ValueProcessingKind.None)),
-            };
+            modifiersDictionary.TryGetValue("BurstModeEnabled", out Modifier? modifierData);
+            var modifiers = new List<Modifier> { new("BurstModeEnabled", 1, shipName, modifierData) };
 
             foreach (var (modifierName, modifierValue) in module.Modifiers)
             {
-                modifiersDictionary.TryGetValue(modifierName, out Modifier? modifierData);
+                modifiersDictionary.TryGetValue(modifierName, out modifierData);
                 modifiers.Add(new(modifierName, modifierValue, shipName, modifierData));
             }
 
@@ -283,7 +281,7 @@ public static class ShipConverter
         return upgradeInfo;
     }
 
-    private static ImmutableDictionary<string, TurretModule> ProcessMainBattery(WgShip wgShip, UpgradeInfo upgradeInfo, ShiptoolShip? stShip, ILogger? logger, Dictionary<string, Modifier> modifiersDictionary)
+    private static ImmutableDictionary<string, TurretModule> ProcessMainBattery(WgShip wgShip, UpgradeInfo upgradeInfo, ShiptoolShip? stShip, Dictionary<string, Modifier> modifiersDictionary)
     {
         var resultDictionary = new Dictionary<string, TurretModule>();
         Dictionary<string, WgMainBattery> artilleryModules = wgShip.ModulesArmaments.ModulesOfType<WgMainBattery>();
@@ -294,17 +292,12 @@ public static class ShipConverter
 
             var stHullModule = stShip?.GetHullModule(correspondingHull);
             var burstModeAbility = ProcessBurstModeAbility(wgMainBattery.SwitchableModeArtilleryModule, modifiersDictionary, wgShip.Name);
-            var additionalAmmoList = wgMainBattery.SwitchableModeArtilleryModule?.SecondaryAmmoList.ToImmutableArray() ?? ImmutableArray<string>.Empty;
-            foreach (var ammoModifier in burstModeAbility?.AlternateShells ?? Enumerable.Empty<string>())
-            {
-                additionalAmmoList = additionalAmmoList.Remove(ammoModifier);
-            }
 
             var turretModule = new TurretModule
             {
                 Sigma = wgMainBattery.SigmaCount,
                 MaxRange = wgMainBattery.MaxDist,
-                Guns = wgMainBattery.Guns.Select(entry => ConvertMainBatteryGun(entry.Value, entry.Key, wgMainBattery.TaperDist, stHullModule, additionalAmmoList)).ToImmutableArray(),
+                Guns = wgMainBattery.Guns.Select(entry => ConvertMainBatteryGun(entry.Value, entry.Key, wgMainBattery.TaperDist, stHullModule)).ToImmutableArray(),
                 BurstModeAbility = burstModeAbility,
             };
 
@@ -330,14 +323,14 @@ public static class ShipConverter
             .First(u => u.Components[componentType].Contains(componentKey)).Components[ComponentType.Hull].First();
     }
 
-    private static Gun ConvertMainBatteryGun(WgGun wgGun, string mainGunKey, double taperDist, ShiptoolHullModule? stHull, ImmutableArray<string> additionalAmmo)
+    private static Gun ConvertMainBatteryGun(WgGun wgGun, string mainGunKey, double taperDist, ShiptoolHullModule? stHull)
     {
         if (stHull is null || !stHull.Angles.TryGetValue(mainGunKey, out decimal angle))
         {
             angle = wgGun.Position[0] < 3 ? 0 : 180;
         }
 
-        return wgGun.ConvertData(taperDist, mainGunKey, angle, additionalAmmo);
+        return wgGun.ConvertData(taperDist, mainGunKey, angle);
     }
 
     private static ImmutableDictionary<string, Hull> ProcessShipHull(WgShip wgShip, UpgradeInfo upgradeInfo)
@@ -463,7 +456,7 @@ public static class ShipConverter
                 {
                     Sigma = wgHullSecondary.SigmaCount,
                     MaxRange = wgHullSecondary.MaxDist,
-                    Guns = wgHullSecondary.AntiAirAndSecondaries.Values.Select(secondaryGun => secondaryGun.ConvertData(wgHullSecondary.TaperDist, string.Empty, default, ImmutableArray<string>.Empty)).ToImmutableArray(),
+                    Guns = wgHullSecondary.AntiAirAndSecondaries.Values.Select(secondaryGun => secondaryGun.ConvertData(wgHullSecondary.TaperDist, string.Empty, default)).ToImmutableArray(),
                 };
 
                 DataCache.TranslationNames.UnionWith(secondary.Guns.Select(gun => gun.Name).Distinct());

--- a/DataConverter/Converters/ShipConverter.cs
+++ b/DataConverter/Converters/ShipConverter.cs
@@ -1,17 +1,17 @@
+using DataConverter.Data;
+using DataConverter.JsonData;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
-using DataConverter.Data;
-using DataConverter.JsonData;
-using Microsoft.Extensions.Logging;
-using Newtonsoft.Json.Linq;
+using WowsShipBuilder.GameParamsExtractor.WGStructure.Ship;
 using WoWsShipBuilder.DataStructures;
 using WoWsShipBuilder.DataStructures.Modifiers;
 using WoWsShipBuilder.DataStructures.Ship;
-using WowsShipBuilder.GameParamsExtractor.WGStructure.Ship;
 using Hull = WoWsShipBuilder.DataStructures.Ship.Hull;
 using ShipUpgrade = WoWsShipBuilder.DataStructures.Ship.ShipUpgrade;
 
@@ -42,7 +42,7 @@ public static class ShipConverter
             DataCache.TranslationNames.Add(wgShip.Index);
             var stShip = shiptoolData.Ship.Find(s => s.Index.Equals(wgShip.Index));
             var upgradeInfo = ProcessUpgradeInfo(wgShip, logger);
-            var mainBatteries = ProcessMainBattery(wgShip, upgradeInfo, stShip, modifiersDictionary);
+            var mainBatteries = ProcessMainBattery(wgShip, upgradeInfo, stShip, logger, modifiersDictionary);
             var ship = new Ship
             {
                 Id = wgShip.Id,
@@ -108,13 +108,17 @@ public static class ShipConverter
 
     private static BurstModeAbility? ProcessBurstModeAbility(WgBurstArtilleryModule? module, Dictionary<string, Modifier> modifiersDictionary, string shipName)
     {
-        if (module is { SecondaryAmmoList.Length: 0 })
+        if (module != null)
         {
-            var modifiers = new List<Modifier>();
+            var modifiers = new List<Modifier>
+            {
+                new("BurstModeEnabled", 1, shipName, new("", 0, string.Empty, string.Empty, Unit.None, ["MainBatteryDataContainer.BurstMode"], DisplayValueProcessingKind.Discard, ValueProcessingKind.None)),
+            };
+
             foreach (var (modifierName, modifierValue) in module.Modifiers)
             {
                 modifiersDictionary.TryGetValue(modifierName, out Modifier? modifierData);
-                modifiers.Add(new(modifierName, modifierValue, shipName,  modifierData));
+                modifiers.Add(new(modifierName, modifierValue, shipName, modifierData));
             }
 
             var burstAbility = new BurstModeAbility
@@ -123,6 +127,7 @@ public static class ShipConverter
                 ReloadAfterBurst = module.FullReloadTime,
                 ReloadDuringBurst = module.BurstReloadTime,
                 Modifiers = modifiers.ToImmutableList(),
+                AlternateShells = module.SecondaryAmmoList?.ToImmutableArray() ?? ImmutableArray<string>.Empty,
             };
 
             DataCache.TranslationNames.UnionWith(burstAbility.Modifiers.Select(m => m.Name));
@@ -278,7 +283,7 @@ public static class ShipConverter
         return upgradeInfo;
     }
 
-    private static ImmutableDictionary<string, TurretModule> ProcessMainBattery(WgShip wgShip, UpgradeInfo upgradeInfo, ShiptoolShip? stShip, Dictionary<string, Modifier> modifiersDictionary)
+    private static ImmutableDictionary<string, TurretModule> ProcessMainBattery(WgShip wgShip, UpgradeInfo upgradeInfo, ShiptoolShip? stShip, ILogger? logger, Dictionary<string, Modifier> modifiersDictionary)
     {
         var resultDictionary = new Dictionary<string, TurretModule>();
         Dictionary<string, WgMainBattery> artilleryModules = wgShip.ModulesArmaments.ModulesOfType<WgMainBattery>();
@@ -288,13 +293,19 @@ public static class ShipConverter
             string correspondingHull = FindHullForComponent(upgradeInfo, ComponentType.Artillery, key);
 
             var stHullModule = stShip?.GetHullModule(correspondingHull);
+            var burstModeAbility = ProcessBurstModeAbility(wgMainBattery.SwitchableModeArtilleryModule, modifiersDictionary, wgShip.Name);
             var additionalAmmoList = wgMainBattery.SwitchableModeArtilleryModule?.SecondaryAmmoList.ToImmutableArray() ?? ImmutableArray<string>.Empty;
+            foreach (var ammoModifier in burstModeAbility?.AlternateShells ?? Enumerable.Empty<string>())
+            {
+                additionalAmmoList = additionalAmmoList.Remove(ammoModifier);
+            }
+
             var turretModule = new TurretModule
             {
                 Sigma = wgMainBattery.SigmaCount,
                 MaxRange = wgMainBattery.MaxDist,
                 Guns = wgMainBattery.Guns.Select(entry => ConvertMainBatteryGun(entry.Value, entry.Key, wgMainBattery.TaperDist, stHullModule, additionalAmmoList)).ToImmutableArray(),
-                BurstModeAbility = ProcessBurstModeAbility(wgMainBattery.SwitchableModeArtilleryModule, modifiersDictionary, wgShip.Name),
+                BurstModeAbility = burstModeAbility,
             };
 
             DataCache.TranslationNames.UnionWith(turretModule.Guns.Select(gun => gun.Name).Distinct());

--- a/DataConverter/Converters/ShipConverter.cs
+++ b/DataConverter/Converters/ShipConverter.cs
@@ -1,17 +1,17 @@
-using DataConverter.Data;
-using DataConverter.JsonData;
-using Microsoft.Extensions.Logging;
-using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
-using WowsShipBuilder.GameParamsExtractor.WGStructure.Ship;
+using DataConverter.Data;
+using DataConverter.JsonData;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
 using WoWsShipBuilder.DataStructures;
 using WoWsShipBuilder.DataStructures.Modifiers;
 using WoWsShipBuilder.DataStructures.Ship;
+using WowsShipBuilder.GameParamsExtractor.WGStructure.Ship;
 using Hull = WoWsShipBuilder.DataStructures.Ship.Hull;
 using ShipUpgrade = WoWsShipBuilder.DataStructures.Ship.ShipUpgrade;
 

--- a/DataConverter/JsonData/Modifiers.json
+++ b/DataConverter/JsonData/Modifiers.json
@@ -664,6 +664,15 @@
     "valueProcessingKind": "Multiplier"
   },
   {
+    "name": "BurstModeEnabled",
+    "gameLocalizationKey": "",
+    "appLocalizationKey": null,
+    "unit": "None",
+    "affectedProperties": [],
+    "displayValueProcessingKind": "Discard",
+    "valueProcessingKind": "None"
+  },
+  {
     "name": "callFightersAdditionalConsumables",
     "gameLocalizationKey": "PARAMS_MODIFIER_CALLFIGHTERSADDITIONALCONSUMABLES_SKILL",
     "appLocalizationKey": null,

--- a/WoWsShipBuilder.DataStructures/Ship/SpecialAbility.cs
+++ b/WoWsShipBuilder.DataStructures/Ship/SpecialAbility.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using WoWsShipBuilder.DataStructures.Modifiers;
 
 // ReSharper disable UnusedAutoPropertyAccessor.Global
@@ -27,4 +27,6 @@ public sealed class BurstModeAbility
     public ImmutableList<Modifier> Modifiers { get; init; } = ImmutableList<Modifier>.Empty;
 
     public int ShotInBurst { get; init; }
+
+    public ImmutableArray<string> AlternateShells { get; init; } = ImmutableArray<string>.Empty;
 }


### PR DESCRIPTION
[add "AlternateShells" attr](https://github.com/lkk9898969/DataConverter/commit/bc0347ab5425b894afcec6a0d43c85d457a61b33)
This is for the SB to "convey" the alt shells name.

[Add alt ammo array to BurstModeAbility](https://github.com/lkk9898969/DataConverter/commit/05b7f05b8cb739c1e993409bf3a242bb5410d798)
1. delete the alt ammo in BurstModeAbility in additionalAmmoList, so SB would not display alt ammo used by BurstModeAbility
2. add a modifier to "notice" MainBatteryDataContainer which need to know the F key is on or not.